### PR TITLE
Guess OPERA_PATH / OPERA_LAUNCHER if not set

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,10 @@ group :development do
   gem "bundler", "~> 1.0.0"
   gem "jeweler", "~> 1.5.1"
   gem "rcov", ">= 0"
+  gem "yard", ">= 0.6.3"
+  gem "rspec", ">= 2.0.0"
+  gem "sinatra", ">= 1.0.0"
+  gem "mongrel", ">= 1.1.5"
+  gem "rr", ">= 1.0.2"
 end
 

--- a/lib/operawatir.rb
+++ b/lib/operawatir.rb
@@ -28,6 +28,7 @@ module OperaWatir
 end
 
 require 'operawatir/version'
+require 'operawatir/platform'
 
 require 'operawatir/exceptions'
 require 'operawatir/selector'

--- a/lib/operawatir/browser.rb
+++ b/lib/operawatir/browser.rb
@@ -5,8 +5,8 @@ class OperaWatir::Browser
 
   def self.settings=(settings={})
     @opera_driver_settings = nil # Bust cache
-    @settings = settings.merge! :launcher => ENV['OPERA_LAUNCHER'] || '',
-                                :path     => ENV['OPERA_PATH'] || '',
+    @settings = settings.merge! :launcher => OperaWatir::Platform.launcher,
+                                :path     => OperaWatir::Platform.opera,
                                 :args     => ENV['OPERA_ARGS'] || ''
   end
 
@@ -174,7 +174,7 @@ private
       s.setRunOperaLauncherFromOperaDriver true
       s.setOperaLauncherBinary self.settings[:launcher]
       s.setOperaBinaryLocation self.settings[:path]
-      s.setOperaBinaryArguments self.settings[:args] + (Config::CONFIG['host_os'] =~ /mswin|mingw|bccwin|wince|emc/ ? '' : ' -nosession') + ' opera:debug'
+      s.setOperaBinaryArguments self.settings[:args] + (OperaWatir::Platform.os == :windows ? '' : ' -nosession') + ' opera:debug'
     }
   end
 

--- a/lib/operawatir/platform.rb
+++ b/lib/operawatir/platform.rb
@@ -1,0 +1,69 @@
+require "rbconfig"
+
+class OperaWatir::Platform
+  def self.launcher
+    return ENV['OPERA_LAUNCHER'] if ENV['OPERA_LAUNCHER']
+
+    path = case os
+    when :windows
+      raise Exceptions::NotImplementedException, "only 32-bit windows supported" if bitsize == 64
+      "utils/launchers/launcher-win32-i86pc.exe"
+    when :linux
+      postfix = bitsize == 64 ? "x86_64" : "i686"
+      "utils/launchers/launcher-linux-#{postfix}"
+    end
+
+    if path
+      File.join(root, path)
+    else
+      raise Exceptions::NotImplementedException, "no known launcher for #{os.inspect}, set OPERA_LAUNCHER to override"
+    end
+
+  end
+
+  def self.opera
+    return ENV['OPERA_PATH'] if ENV['OPERA_PATH']
+
+    path = case os
+    when :windows
+      "#{ENV['PROGRAMFILES'] || "\\Program Files"}\\Opera\\opera.exe"
+    when :linux
+      "/usr/bin/opera"
+    else
+      raise Exceptions::NotImplementedException, "#{os} not supported"
+    end
+
+    unless File.exist? path
+      raise "Opera not found at #{path.inspect}, set OPERA_PATH to override"
+    end
+
+    path
+  end
+
+  def self.os
+    @os ||= (
+      host_os = RbConfig::CONFIG['host_os']
+      case host_os
+      when /mswin|msys|mingw|bccwin|wince|emc/
+        :windows
+      when /darwin|mac os/
+        :macosx
+      when /linux/
+        :linux
+      when /solaris|bsd/
+        :unix
+      else
+        raise Exceptions::NotImplementedException, "#{host_os.inspect} not supported"
+      end
+    )
+  end
+
+  def self.bitsize
+    Integer(ENV_JAVA['sun.arch.data.model'])
+  end
+
+  def self.root
+    @root ||= File.expand_path("../../..", __FILE__)
+  end
+
+end


### PR DESCRIPTION
<pre>
[14:04]      jarib : having people specify OPERA_LAUNCHER to a path inside the gem is a pretty bad UX
[14:04]      jarib : i haven't tested on anything besides linux though
[14:05]      jarib : and i didn't touch any of the desktop stuff
[14:05]      jarib : which probably should use the same approach
</pre>


Also updated the Gemfile with current dependencies.
